### PR TITLE
fix: update action versions to use dynamic references

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -27,7 +27,7 @@ jobs:
         terraform_version: "1.0.0"
 
     - name: Download Plan
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@latest
       with:
         name: terraform-plan
         path: terraform

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -18,7 +18,7 @@ jobs:
         terraform_version: "1.0.0"
 
     - name: TFLint
-      uses: terraform-linters/tflint-action@v2
+      uses: terraform-linters/tflint-action@latest
       with:
         working_directory: terraform
         config_file: .tflint.hcl
@@ -40,7 +40,7 @@ jobs:
         TF_LOG: "ERROR"
 
     - name: Upload Plan
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@latest
       with:
         name: terraform-plan
         path: terraform/tfplan

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -28,14 +28,14 @@ jobs:
       working-directory: terraform
 
     - name: Run TFSec
-      uses: aquasecurity/tfsec@v1
+      uses: aquasecurity/tfsec-action@latest
       with:
         working_dir: terraform
         fail_on_violations: true
         skip_check: "check:tfsec:aws:ec2:EnsureEC2InstanceIsInVPC"
 
     - name: Run TFLint
-      uses: terraform-linters/tflint-action@v2
+      uses: terraform-linters/tflint-action@latest
       with:
         working_directory: terraform
         config_file: .tflint.hcl


### PR DESCRIPTION
This PR updates all GitHub Actions to use dynamic version references (latest) instead of specific versions. This change:

- Allows GitHub Actions to automatically use the latest stable version of each action
- Eliminates the need to manually update version numbers
- Ensures compatibility between action versions
- Should resolve the previous workflow errors we were experiencing

Changes made:
- All actions now use @latest instead of specific version numbers
- Maintains compatibility with our current workflow structure
- Ensures we're always using the most recent, tested versions of each action