### PR TITLE
fix: use specific version for artifact actions

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -27,7 +27,7 @@ jobs:
         terraform_version: "1.0.0"
 
     - name: Download Plan
-      uses: actions/download-artifact@latest
+      uses: actions/download-artifact@v4.2.1
       with:
         name: terraform-plan
         path: terraform

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -40,7 +40,7 @@ jobs:
         TF_LOG: "ERROR"
 
     - name: Upload Plan
-      uses: actions/upload-artifact@latest
+      uses: actions/upload-artifact@v4.2.1
       with:
         name: terraform-plan
         path: terraform/tfplan


### PR DESCRIPTION
This PR updates the artifact actions to use specific version numbers instead of @latest. This is necessary because the artifact actions require pinned versions for stability.

Changes made:
- Changed actions/upload-artifact@latest to actions/upload-artifact@v4.2.1
- Changed actions/download-artifact@latest to actions/download-artifact@v4.2.1
- Maintained @latest for other actions that support it

This should resolve the workflow errors we were experiencing with the artifact actions.