### PR TITLE
fix: use specific version for tfsec-action

### DIFF
--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -28,7 +28,7 @@ jobs:
       working-directory: terraform
 
     - name: Run TFSec
-      uses: aquasecurity/tfsec-action@latest
+      uses: aquasecurity/tfsec-action@v1.0.3
       with:
         working_dir: terraform
         fail_on_violations: true


### PR DESCRIPTION
This PR updates the tfsec-action to use a specific version number instead of @latest. This is necessary because the tfsec-action requires a pinned version for stability.

Changes made:
- Changed aquasecurity/tfsec-action@latest to aquasecurity/tfsec-action@v1.0.3
- Maintained @latest for other actions that support it
- This should resolve the workflow errors we were experiencing with tfsec-action