### PR TITLE
fix: Configure ACR access using system-assigned identity

### DIFF
--- a/terraform/modules/aks/main.tf
+++ b/terraform/modules/aks/main.tf
@@ -32,9 +32,16 @@ resource "azurerm_kubernetes_cluster" "aks" {
     environment = var.environment
     project     = "fp6"
   }
+
+  # Grant ACR pull access to the system-assigned identity
+  identity_profile {
+    kubeletidentity {
+      type = "SystemAssigned"
+    }
+  }
 }
 
-# Grant AKS access to ACR
+# Grant ACR pull access to the system-assigned identity
 resource "azurerm_role_assignment" "aks_acr" {
   principal_id                     = azurerm_kubernetes_cluster.aks.kubelet_identity[0].object_id
   role_definition_name             = "AcrPull"


### PR DESCRIPTION
This PR includes:
- Added explicit identity_profile configuration for kubelet identity
- Using system-assigned identity for ACR access
- This change should resolve the authorization errors during role assignment