### PR TITLE
fix: Remove unsupported identity_profile block

### DIFF
--- a/terraform/modules/aks/main.tf
+++ b/terraform/modules/aks/main.tf
@@ -32,16 +32,9 @@ resource "azurerm_kubernetes_cluster" "aks" {
     environment = var.environment
     project     = "fp6"
   }
-
-  # Grant ACR pull access to the system-assigned identity
-  identity_profile {
-    kubeletidentity {
-      type = "SystemAssigned"
-    }
-  }
 }
 
-# Grant ACR pull access to the system-assigned identity
+# Grant ACR pull access to the AKS identity
 resource "azurerm_role_assignment" "aks_acr" {
   principal_id                     = azurerm_kubernetes_cluster.aks.kubelet_identity[0].object_id
   role_definition_name             = "AcrPull"


### PR DESCRIPTION
This PR includes:
- Removed the unsupported identity_profile block
- Kept the system-assigned identity configuration
- The ACR role assignment will use the kubelet identity