### PR TITLE
fix: add id-token permission for Azure login

### DIFF
--- a/.github/workflows/deploy-weather-app.yml
+++ b/.github/workflows/deploy-weather-app.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write
 
 env:
   REGISTRY: fp6acr.azurecr.io


### PR DESCRIPTION
## Changes
- Added id-token permission to the workflow
- Fixes Azure login error in deployment pipeline

## Testing
- Workflow should now authenticate successfully with Azure
- Deployment steps will proceed after successful authentication

## Notes
- Required for Azure login action to access necessary tokens
- This permission is needed for proper Azure authentication in GitHub Actions