### PR TITLE
fix: update Azure login to use creds parameter

### DIFF
--- a/.github/workflows/deploy-weather-app.yml
+++ b/.github/workflows/deploy-weather-app.yml
@@ -31,10 +31,7 @@ jobs:
     - name: Login to Azure
       uses: azure/login@v1
       with:
-        client-id: ${{ secrets.AZURE_CLIENT_ID }}
-        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-        client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
-        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        creds: ${{ secrets.AZURE_CREDENTIALS }}
         auth-type: SERVICE_PRINCIPAL
 
     - name: Login to ACR


### PR DESCRIPTION
## Changes
- Updated Azure login to use creds parameter instead of individual credentials
- Fixes OIDC authentication issue

## Testing
- Workflow should now authenticate successfully with Azure
- Deployment steps will proceed after successful authentication

## Notes
- Requires AZURE_CREDENTIALS secret to be configured with proper credentials
- This is the recommended way to authenticate with Azure in GitHub Actions