### PR TITLE
fix: use creds parameter with existing secrets

### DIFF
--- a/.github/workflows/deploy-weather-app.yml
+++ b/.github/workflows/deploy-weather-app.yml
@@ -31,8 +31,13 @@ jobs:
     - name: Login to Azure
       uses: azure/login@v1
       with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }}
-        auth-type: SERVICE_PRINCIPAL
+        creds: |
+          {
+            "clientId": "${{ secrets.AZURE_CLIENT_ID }}",
+            "clientSecret": "${{ secrets.AZURE_CLIENT_SECRET }}",
+            "tenantId": "${{ secrets.AZURE_TENANT_ID }}",
+            "subscriptionId": "${{ secrets.AZURE_SUBSCRIPTION_ID }}"
+          }
 
     - name: Login to ACR
       run: |


### PR DESCRIPTION
## Changes
- Updated Azure login to use creds parameter with proper JSON format
- Using existing secrets (AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID)
- Removed auth-type parameter since it's not needed with creds

## Testing
- Workflow should now authenticate successfully with Azure
- Deployment steps will proceed after successful authentication

## Notes
- This approach uses the existing secrets we already have configured
- The creds parameter is properly formatted with all necessary credentials