### PR TITLE
fix: remove infinite watch from service details

### DIFF
--- a/.github/workflows/deploy-weather-app.yml
+++ b/.github/workflows/deploy-weather-app.yml
@@ -75,4 +75,6 @@ jobs:
         echo "Waiting for service IP..."
         kubectl get service -n $NAMESPACE
         echo "Waiting for external IP..."
-        kubectl get service weather-app-service -n $NAMESPACE --watch
+        kubectl get service weather-app-service -n $NAMESPACE
+        echo "Service is deployed. You can access it at:"
+        kubectl get service weather-app-service -n $NAMESPACE -o jsonpath='{.status.loadBalancer.ingress[0].ip}'


### PR DESCRIPTION
## Changes
- Removed infinite watch from kubectl get service command
- Added command to print external IP directly
- Pipeline will now complete without hanging

## Testing
- Pipeline should complete successfully
- External IP will be printed at the end
- Service will be accessible at the printed IP address

## Notes
- The service is already deployed and accessible
- This change just improves the pipeline output